### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().ignoringAntMatchers("/api/**").and() // Allow CSRF bypass for API endpoints
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/mrtokarev/ghas-bootcamp-workshop/security/code-scanning/5](https://github.com/mrtokarev/ghas-bootcamp-workshop/security/code-scanning/5)

To fix the issue, CSRF protection should be re-enabled unless there is a compelling reason to disable it. If certain endpoints need to bypass CSRF protection (e.g., for APIs used by non-browser clients), this can be achieved by configuring CSRF protection to ignore specific request patterns. 

The following changes will:
1. Remove the `http.csrf().disable()` call.
2. Configure CSRF protection to allow specific endpoints (if necessary) while keeping it enabled for the rest of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
